### PR TITLE
Specifying an image tag each time CICD is executed

### DIFF
--- a/embedding_service.yaml
+++ b/embedding_service.yaml
@@ -36,7 +36,7 @@ steps:
     args:
       - build 
       - '-t'
-      - 'northamerica-south1-docker.pkg.dev/$PROJECT_ID/dev-rag-llm-artifact/embedding_service:latest'
+      - 'northamerica-south1-docker.pkg.dev/$PROJECT_ID/dev-rag-llm-artifact/embedding_service:$SHORT_SHA'
       - '-f' 
       - './rag_llm_energy_expert/services/embeddings/embeddings_service.dockerfile'
       - './rag_llm_energy_expert/services/embeddings'
@@ -45,7 +45,7 @@ steps:
     name: 'gcr.io/cloud-builders/docker'
     args:
       - push 
-      - 'northamerica-south1-docker.pkg.dev/$PROJECT_ID/dev-rag-llm-artifact/embedding_service:latest'
+      - 'northamerica-south1-docker.pkg.dev/$PROJECT_ID/dev-rag-llm-artifact/embedding_service:$SHORT_SHA'
   
   - id: 'deploy embedding service'
     name: 'hashicorp/terraform'
@@ -54,7 +54,7 @@ steps:
       - '-c'
       - |
         cd terraform
-        terraform apply -var-file='dev/dev.tfvars' \
+        terraform apply -var-file='dev/dev.tfvars' -var="embedding_service_image_name=$SHORT_SHA"\
         -target=google_cloud_run_v2_service.cloudrun_embeddings_instance \
         -target=google_cloud_run_v2_service_iam_member.noauth \
         -auto-approve -target=google_cloud_run_v2_service.cloudrun_embeddings_instance

--- a/embedding_service.yaml
+++ b/embedding_service.yaml
@@ -54,7 +54,7 @@ steps:
       - '-c'
       - |
         cd terraform
-        terraform apply -var-file='dev/dev.tfvars' -var="embedding_service_tag_image=$SHORT_SHA"\
+        terraform apply -var-file='dev/dev.tfvars' -var="embedding_service_tag_image=$SHORT_SHA" \
         -target=google_cloud_run_v2_service.cloudrun_embeddings_instance \
         -target=google_cloud_run_v2_service_iam_member.noauth \
         -auto-approve -target=google_cloud_run_v2_service.cloudrun_embeddings_instance

--- a/embedding_service.yaml
+++ b/embedding_service.yaml
@@ -54,7 +54,7 @@ steps:
       - '-c'
       - |
         cd terraform
-        terraform apply -var-file='dev/dev.tfvars' -var="embedding_service_image_name=$SHORT_SHA"\
+        terraform apply -var-file='dev/dev.tfvars' -var="embedding_service_tag_image=$SHORT_SHA"\
         -target=google_cloud_run_v2_service.cloudrun_embeddings_instance \
         -target=google_cloud_run_v2_service_iam_member.noauth \
         -auto-approve -target=google_cloud_run_v2_service.cloudrun_embeddings_instance

--- a/embedding_service.yaml
+++ b/embedding_service.yaml
@@ -3,7 +3,7 @@
 steps:
   
   - id: 'tf plan'
-    name: 'hashicorp/terraform:1.11.3'
+    name: 'hashicorp/terraform'
     entrypoint: 'sh'
     args: 
      - '-c'

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -27,7 +27,7 @@ resource "google_cloud_run_v2_service" "cloudrun_embeddings_instance" {
 
   template {
     containers {
-      image = "${var.gcp_region}-docker.pkg.dev/${var.gcp_project_id}/${var.env_prefix}-${var.artifact_registry_name}/embedding_service:latest"
+      image = "${var.gcp_region}-docker.pkg.dev/${var.gcp_project_id}/${var.env_prefix}-${var.artifact_registry_name}/embedding_service:${var.embedding_service_image_name}"
       ports {
         container_port = var.cloudrun_embeddings_instance_port
       }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -27,7 +27,7 @@ resource "google_cloud_run_v2_service" "cloudrun_embeddings_instance" {
 
   template {
     containers {
-      image = "${var.gcp_region}-docker.pkg.dev/${var.gcp_project_id}/${var.env_prefix}-${var.artifact_registry_name}/embedding_service:${var.embedding_service_image_name}"
+      image = "${var.gcp_region}-docker.pkg.dev/${var.gcp_project_id}/${var.env_prefix}-${var.artifact_registry_name}/embedding_service:${var.embedding_service_tag_image}"
       ports {
         container_port = var.cloudrun_embeddings_instance_port
       }

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -52,3 +52,8 @@ variable "gcp_dev_sa" {
   description = "Developer service account"
   default     = "dev-service-account@learned-stone-454021-c8.iam.gserviceaccount.com"
 }
+
+variable "embedding_service_image_name" {
+  type        = string
+  description = "Name of the image to be deployed"
+}

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -53,7 +53,8 @@ variable "gcp_dev_sa" {
   default     = "dev-service-account@learned-stone-454021-c8.iam.gserviceaccount.com"
 }
 
-variable "embedding_service_image_name" {
+variable "embedding_service_tag_image" {
   type        = string
   description = "Name of the image to be deployed"
+  default     = "mock_tag_image"
 }


### PR DESCRIPTION
Setting a specific tag to the image build each time the embedding service CICD is executed

This is because when I deployed the image with tag:latest, terraform did not know that the image was modified (because the tag was the same), so it didn't modify the CloudRun instance

Now the image tag will be the first 7 characters of the commit sha