### PR TITLE
Add field validators to EmbeddingRequest model

### DIFF
--- a/rag_llm_energy_expert/services/embeddings/app/models.py
+++ b/rag_llm_energy_expert/services/embeddings/app/models.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from typing import Optional, Union
 
 import sys
@@ -31,16 +31,32 @@ class EmbeddingRequest(BaseModel):
     text: str = Field(
         description="String with the whole text to be embedded", min_length=1
     )
-    embedding_model_name: Optional[str] = Field(
+    embedding_model_name: Optional[Union[str, None]] = Field(
         default=embeddings_config.EMBEDDING_MODEL,
         min_length=1,
         description="Name of the embedding model. Must be available on SentenceTransformers.",
     )
-    chunk_overlap: Optional[int] = Field(default=embeddings_config.CHUNK_OVERLAP, ge=0)
-    metadata: Optional[dict[str, str]] = Field(
+    chunk_overlap: Optional[Union[int, None]] = Field(
+        default=embeddings_config.CHUNK_OVERLAP, ge=0
+    )
+    metadata: Optional[Union[dict[str, str], None]] = Field(
         default=None,
         description="Data associated to the text. Ex: {'title':'title_name', 'date':'9999-12-23'}.",
     )
+
+    @field_validator("embedding_model_name", mode="after")
+    @classmethod
+    def validate_embedding_model_name(cls, value):
+        if value is None:
+            return embeddings_config.EMBEDDING_MODEL
+        return value
+
+    @field_validator("chunk_overlap", mode="after")
+    @classmethod
+    def validate_chunk_overlap(cls, value):
+        if value is None:
+            return embeddings_config.CHUNK_OVERLAP
+        return value
 
 
 class EmbeddingResponse(BaseModel):


### PR DESCRIPTION
Before the endpoint does not allow to set input parameters as None. When you try to set the default value, you needed to not enter the parameter in the json, which was not the ideal behaviour.

Now, if you set the optional parameters as None, the default values will be taken. If you do not write the parameter, the default value is set too.